### PR TITLE
Add a command to run Test262 tests for spec conformance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "scripts/data/fullcalendar"]
 	path = scripts/data/fullcalendar
 	url = https://github.com/fullcalendar/fullcalendar.git
+[submodule "packages/temporal-polyfill/test262"]
+	path = packages/temporal-polyfill/test262
+	url = https://github.com/tc39/test262

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,23 @@
       "args": ["run", "jest", "--runInBand", "--no-cache", "--watchAll=false", "${file}"],
       "sourceMaps": true,
       "disableOptimisticBPs": true
+    },
+    {
+      "name": "Test262",
+      "request": "launch",
+      "type": "node",
+      "runtimeExecutable": "yarn",
+      // To run only specific tests, set the third argument below
+      // to a glob pattern for the filenames of tests you want to run.
+      "runtimeArgs": ["run", "test262", "**"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "autoAttachChildProcesses": true,
+      "env": {
+        // Msecs before killing a test. To debug a test at a breakpoint,
+        // increase this timeout.
+        "TIMEOUT": "1000"
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "types": "tsc --build --preserveWatchOutput",
     "bundle": "rollup -c ./scripts/config/bundle.cjs",
     "test": "jest",
+    "test262": "TEST262=1 yarn build && cd packages/temporal-polyfill && node ./runtest262.mjs",
     "lint": "eslint .",
     "size": "yall -pwq pkg:size",
     "pkg:clean": "cd $INIT_CWD && node $PROJECT_CWD/scripts/pkgClean.cjs",

--- a/packages/temporal-polyfill/expected-failures.txt
+++ b/packages/temporal-polyfill/expected-failures.txt
@@ -1,0 +1,20 @@
+# expected failures unrelated to Node versions
+intl402/Temporal/TimeZone/prototype/getNextTransition/transition-at-instant-boundaries.js
+intl402/Temporal/TimeZone/prototype/getPreviousTransition/transition-at-instant-boundaries.js
+
+# Intl.supportedValuesOf("timeZone") is only available starting in Node 18
+intl402/Temporal/TimeZone/supported-values-of.js 18
+
+# Before Node 16, dateStyle/timeStyle options didn't conflict with other options
+intl402/Temporal/Instant/prototype/toLocaleString/options-conflict.js 16
+intl402/Temporal/PlainDate/prototype/toLocaleString/options-conflict.js 16
+intl402/Temporal/PlainDateTime/prototype/toLocaleString/options-conflict.js 16
+intl402/Temporal/PlainTime/prototype/toLocaleString/options-conflict.js 16
+intl402/Temporal/ZonedDateTime/prototype/toLocaleString/options-conflict.js 16
+
+# Before Node 16, calling an uncallable value seems to throw a RangeError, not a TypeError
+intl402/Temporal/PlainYearMonth/prototype/toLocaleString/timezone-getoffsetnanosecondsfor-not-callable.js 16
+intl402/Temporal/PlainMonthDay/prototype/toLocaleString/timezone-getoffsetnanosecondsfor-not-callable.js 16
+intl402/Temporal/PlainDate/prototype/toLocaleString/timezone-getoffsetnanosecondsfor-not-callable.js 16
+intl402/Temporal/PlainDateTime/prototype/toLocaleString/timezone-getoffsetnanosecondsfor-not-callable.js 16
+intl402/Temporal/PlainTime/prototype/toLocaleString/timezone-getoffsetnanosecondsfor-not-callable.js 16

--- a/packages/temporal-polyfill/package.json
+++ b/packages/temporal-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temporal-polyfill",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "title": "Temporal Polyfill",
   "description": "A spec-compliant Temporal JavaScript polyfill in 16kb",
   "author": {
@@ -58,9 +58,13 @@
     "@types/chai": "^4.2.22",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.9.1",
+    "ansi-colors": "^4.1.3",
     "chai": "^4.3.4",
     "jest": "^27.0.6",
     "jest-date-mock": "^1.0.8",
+    "js-yaml": "^4.1.0",
+    "progress": "^2.0.3",
+    "tiny-glob": "^0.2.9",
     "typescript": "^4.3.5"
   }
 }

--- a/packages/temporal-polyfill/runtest262.mjs
+++ b/packages/temporal-polyfill/runtest262.mjs
@@ -1,0 +1,313 @@
+import color from 'ansi-colors'
+import fs from 'node:fs'
+import globSync from 'tiny-glob/sync.js'
+import path from 'node:path'
+import process from 'node:process'
+import ProgressBar from 'progress'
+import util from 'node:util'
+import vm from 'node:vm'
+import yaml from 'js-yaml'
+
+// = Temporal test262 runner =
+
+// This is a lightweight runner for Temporal's test262 tests. It exists in order
+// to be fast, and it is specific to Temporal. It doesn't provide all of the
+// facilities that the full test262 suite would expect. It achieves the "fast"
+// goal by parsing the Temporal polyfill once into a vm.Script, instead of
+// reading and parsing the whole file once for each test like the prelude option
+// of test262-harness would.
+
+// Without any arguments, all of the Temporal tests will be run. The script
+// takes as arguments any number of glob patterns relative to
+// test262/test/*/Temporal/, each of which specify a subset of tests to be run.
+// For example:
+//   "PlainDateTime/**" "*/prototype/with/*.js"
+//   "**/basic.js"
+// If a pattern doesn't match any test files relative to Temporal/, it will also
+// try to match test files relative to the current working directory, so that
+// tab completion works.
+
+// For code coverage, run it with the environment variable NODE_V8_COVERAGE set
+// to a path relative to the cwd, where coverage metrics will be output. These
+// can be processed with the c8 tool.
+
+// Note, as of Node 18.7 there is a memory leak that makes it impossible to run
+// the entire suite with NODE_V8_COVERAGE, so you should run it in chunks.
+
+let timeout = parseInt(process.env.TIMEOUT)
+if (!timeout || isNaN(timeout)) timeout = 1000
+
+// Time the whole thing from start to finish
+const start = process.hrtime.bigint()
+
+// === Utilities and constants ===
+
+function print(str) {
+  process.stdout.write(str + '\n')
+}
+
+// Fancy output only if stdout is a terminal
+color.enabled = process.stdout.isTTY
+
+// Front matter consists of a YAML document in between /*--- and ---*/
+const frontmatterMatcher = /\/\*---\n(.*)---\*\//ms
+
+const UTF8 = { encoding: 'utf-8' }
+const GLOB_OPTS = { filesOnly: true }
+
+// EX_NOINPUT -- An input file (not a system file) did not exist or was not readable.
+const EX_NOINPUT = 66
+
+// === Preparation ===
+
+// Prepare Temporal polyfill. This vm.Script gets executed once for each test,
+// in a fresh VM context.
+
+const polyfillCode = fs.readFileSync('dist/global.js', UTF8)
+const polyfill = new vm.Script(polyfillCode, {
+  filename: path.resolve('dist/global.js'),
+})
+
+// Read the expected failures file and put the paths into a Set
+// If a Node version is provided in a line, that's the minimum major version
+// where the test is expected to pass. If the current Node version is equal to
+// or greater, then it's not an expected failure here.
+
+const nodeVersion = parseInt(process.versions.node.split('.')[0])
+const expectedFailures = new Set(
+  fs
+    .readFileSync('./expected-failures.txt', UTF8)
+    .split(/\r?\n/g)
+    .filter((line) => {
+      if (!line) return false
+      if (line[0] === '#') return false
+
+      // Is it expected to fail in this Node version?
+      const [, minNodeVersion] = line.split(' ')
+      if (minNodeVersion && nodeVersion >= parseInt(minNodeVersion)) return false
+      return true
+    })
+    .map((line) => line.split(' ')[0]),
+)
+
+// This function reads in a test262 harness helper file, specified in 'includes'
+// in the frontmatter, and caches the resulting vm.Script so it can be used in
+// future tests that also include it.
+
+const helpersCache = new Map()
+function getHelperScript(includeName) {
+  if (helpersCache.has(includeName)) return helpersCache.get(includeName)
+
+  const includeFile = `test262/harness/${includeName}`
+  const includeCode = fs.readFileSync(includeFile, UTF8)
+  const include = new vm.Script(includeCode)
+
+  helpersCache.set(includeName, include)
+  return include
+}
+
+// Weed out common error case for people who have just cloned the repo
+if (!fs.statSync('test262/test/').isDirectory()) {
+  print(
+    color.yellow(
+      "Missing Test262 directory. Try initializing submodule with 'git submodule update --init'",
+    ),
+  )
+  process.exit(EX_NOINPUT)
+}
+
+const testGlobs = process.argv.slice(2)
+const globResults = testGlobs.flatMap((testGlob) => {
+  let result = globSync(`test262/test/**/Temporal/${testGlob}`, GLOB_OPTS)
+
+  // Fall back to globbing relative to working directory if that didn't match
+  // anything, in case user is using tab completion
+  if (result.length === 0) {
+    result = globSync(testGlob, GLOB_OPTS)
+  }
+
+  result = result.filter((name) => name.endsWith('.js'))
+  if (result.length === 0) {
+    print(color.yellow(`No test files found for pattern: "${testGlob}"`))
+  }
+  return result
+})
+if (testGlobs.length === 0) {
+  [
+    'test262/test/**/Temporal/**/*.js',
+    // "p*" is a workaround because there is no toTemporalInstant dir at this time
+    'test262/test/built-ins/Date/p*/toTemporalInstant/*.js',
+  ].forEach((defaultGlob) =>
+    globResults.push(...globSync(defaultGlob, GLOB_OPTS)),
+  )
+}
+
+const testFiles = new Set(globResults)
+const total = testFiles.size
+if (total === 0) {
+  print('Nothing to do.')
+  process.exit(EX_NOINPUT)
+}
+
+// Set up progress bar; don't print one if stdout isn't a terminal, instead use
+// a mock object. (You can force that case by piping the output to cat)
+let progress
+if (process.stdout.isTTY) {
+  progress = new ProgressBar(
+    ':bar :percent (:current/:total) | :etas | :test',
+    {
+      total,
+      complete: '\u2588',
+      incomplete: '\u2591',
+      width: 20,
+      stream: process.stdout,
+      renderThrottle: 50,
+      clear: true,
+    },
+  )
+} else {
+  progress = new (class FakeProgressBar {
+    #done = 0;
+
+    tick(delta = 1) {
+      this.#done += delta
+      // Do print _something_ every 100 tests, so that there is something to
+      // look at in the CI while it is in progress.
+      if (delta && this.#done % 100 === 0) {
+        const elapsed = Number(process.hrtime.bigint() - start) / 1_000_000_000
+        print(
+          `${this.#done} tests completed in ${elapsed.toFixed(1)} seconds.`,
+        )
+      }
+    }
+
+    interrupt() {}
+  })()
+}
+
+const failures = []
+const unexpectedPasses = []
+const longTests = []
+let passCount = 0
+let expectedFailCount = 0
+
+// === The test loop ===
+
+for (const testFile of testFiles) {
+  // Set up the VM context with the polyfill first, as if it were built-in
+  const testContext = {}
+  vm.createContext(testContext)
+  polyfill.runInContext(testContext)
+
+  // To proceed, we will now need to read the frontmatter
+  const testCode = fs.readFileSync(testFile, UTF8)
+
+  const frontmatterString = frontmatterMatcher.exec(testCode)?.[1] ?? ''
+  const frontmatter = yaml.load(frontmatterString)
+
+  const { flags = [], includes = [] } = frontmatter ?? {}
+
+  // Load whatever helpers the test specifies. As per the test262 execution
+  // instructions, assert.js and sta.js are always executed even if not
+  // specified, unless the raw flag is given.
+  if (!flags.includes('raw')) includes.unshift('assert.js', 'sta.js')
+  includes.forEach((includeName) => {
+    getHelperScript(includeName).runInContext(testContext)
+  })
+
+  // Various forms of the test's path and filename. testRelPath matches what
+  // is given in the expected failures file. testDisplayName is a slightly
+  // abbreviated form that we use in logging during the run to make it more
+  // likely to fit on one line. progressDisplayName is what's displayed beside
+  // the progress bar: testDisplayName with the actual test filename cut off,
+  // since the individual tests go by too fast to read anyway.
+  const testRelPath = path.relative('test262/test', testFile)
+  const testDisplayName = testRelPath
+    .replace('built-ins/Temporal/', '')
+    .replace('intl402/Temporal/', '(intl) ')
+    .replace('staging/Temporal/', '(staging) ')
+    .replace('/prototype/', '/p/')
+  const progressDisplayName = path.dirname(testDisplayName)
+  progress.tick(0, { test: progressDisplayName })
+
+  // Time each test individually in order to report if they take longer than
+  // 100 ms
+  const testStart = process.hrtime.bigint()
+
+  // Run the test and log a message above the progress bar if the result is not
+  // what it's supposed to be. This is so that you don't have to wait until the
+  // end to see if your test failed.
+  try {
+    vm.runInContext(testCode, testContext, { timeout })
+    passCount++
+
+    if (expectedFailures.has(testRelPath)) {
+      unexpectedPasses.push(testRelPath)
+      progress.interrupt(`UNEXPECTED PASS: ${testDisplayName}`)
+    }
+  } catch (e) {
+    if (expectedFailures.has(testRelPath)) {
+      expectedFailCount++
+    } else {
+      failures.push({ file: testRelPath, error: e })
+      progress.interrupt(`FAIL: ${testDisplayName}`)
+    }
+  }
+
+  const testFinish = process.hrtime.bigint()
+  const testTime = testFinish - testStart
+  if (testTime > 100_000_000n) {
+    longTests.push({ file: testRelPath, ns: testTime })
+  }
+
+  progress.tick(1, { test: progressDisplayName })
+}
+
+// === Print results ===
+
+const finish = process.hrtime.bigint()
+const elapsed = Number(finish - start) / 1_000_000_000
+
+print(color.underline('\nSummary of results:'))
+
+if (failures.length > 0) {
+  failures.forEach(({ file, error }) => {
+    print(color.yellow(`\n${color.bold('FAIL')}: ${file}`))
+    if (error.constructor.name === 'Test262Error') {
+      print(` \u2022 ${error.message}`)
+    } else {
+      print(util.inspect(error, { colors: color.enabled }))
+    }
+  })
+}
+
+if (unexpectedPasses.length > 0) {
+  print(
+    `\n${color.yellow.bold(
+      'WARNING:',
+    )} Tests passed unexpectedly; remove them from expected-failures.txt?`,
+  )
+  unexpectedPasses.forEach((file) => print(` \u2022  ${file}`))
+}
+
+if (longTests.length > 0) {
+  print('\nThe following tests took a long time:')
+  longTests.forEach(({ file, ns }) => {
+    print(`  ${color.yellow(Math.round(Number(ns) / 1_000_000))} ms: ${file}`)
+  })
+}
+
+print(`\n${total} tests finished in ${color.bold(elapsed.toFixed(1))} s`)
+print(color.green(`  ${passCount} passed`))
+print(color.red(`  ${failures.length} failed`))
+if (expectedFailCount > 0) {
+  print(
+    color.cyan(
+      `  ${expectedFailCount} expected failure${
+        expectedFailCount === 1 ? '' : 's'
+      }`,
+    ),
+  )
+}
+
+process.exit(failures.length > 0 ? 1 : 0)

--- a/scripts/lib/pkgBundle.cjs
+++ b/scripts/lib/pkgBundle.cjs
@@ -8,6 +8,8 @@ const dts = require('rollup-plugin-dts').default
 const { createTypeInputHash, typePreparing } = require('../lib/pkgTypes.cjs')
 const terserConfig = require('../config/terser.json')
 
+const isTest262 = !!process.env.TEST262
+
 module.exports = {
   buildPkgBundleConfigs,
 }
@@ -94,7 +96,7 @@ function buildPlugins(watch) {
       target: 'es2018',
     }),
     tsFileOverriding('.build.ts'),
-    !watch && terser(terserConfig),
+    !watch && !isTest262 && terser(terserConfig),
   ]
 }
 


### PR DESCRIPTION
This PR fixes #3 by adding a new command `yarn run test262` that runs 6000+ Temporal-related tests in  [Test262](https://github.com/tc39/test262) (the TC39 spec-conformance test suite) against this repo's Temporal polyfill.

The current results are below. The good news: 3500+ tests pass!  The bad news: 2700+ tests fail. ☹️ 

```
6302 tests finished in 16.0 s
  3584 passed
  2716 failed
```

Test262 files are checked in as a git submodule which will need to be updated periodically like all submodules.

I used the optimized test runner from the tc39/proposal-temporal repo, with only a few minor changes to adapt to this polyfill.

When running Test262 tests, terser is turned off for easier debugging and so that the test runner output doesn't emit indecipherable, long output when tests fail.

I also added a launch.json profile for debugging Test262 tests in VS Code.  Something seems to be messed up with the sourcemap because when I break inside the debugger, the wrong line of code inside the polyfill is highlighted in the IDE. I wasn't sure if this was a pre-existing problem or not, so didn't try to fix it here. 

I didn't check in yarn.lock with this PR because I had trouble getting the polyfill to build without upgrading yarn, and I was hesitant to check in those upgrades.

I also didn't include Test262 in the `yarn test` script that gates all PRs, because there's likely a lot of work required to get those 2700+ tests passing in the meantime.

Let me know how you'd like me to proceed with this PR!